### PR TITLE
Add release/1.4 branch (and speculative branches for future versions of CSM) and PCS.

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -35,6 +35,8 @@ github-repo-image-lookup:
     image: hms-shcd-parser
   - github-repo: hms-trs-worker-http-v1
     image: hms-trs-worker-http-v1
+  - github-repo: hms-capmc
+    image: cray-capmc
 configuration:
   manifest-repo: csm
   targeted-csm-branches:
@@ -63,6 +65,8 @@ docker-image-compare:
       hms-trs-worker-http-v1:
         - find_me
       hardware-topology-assistant:
+        - find_me
+      cray-capmc:
         - find_me
 non-manifest-images:
 - github-repo: hms-test

--- a/configuration.yaml
+++ b/configuration.yaml
@@ -28,6 +28,8 @@ helm-repo-lookup:
     path: stable/cray-hms-trs-operator
   - chart: cray-hms-hmcollector
     path: stable/hms-hmcollector
+  - chart: cray-power-control
+    path: stable/cray-hms-power-control
 github-repo-image-lookup:
   - github-repo: hms-shcd-parser
     image: hms-shcd-parser
@@ -37,12 +39,18 @@ configuration:
   manifest-repo: csm
   targeted-csm-branches:
     - main
+    - release/1.9
+    - release/1.8
+    - release/1.7
+    - release/1.6
+    - release/1.5
+    - release/1.4
     - release/1.3
     - release/1.3.0
     - stable/1.2
   docker-image-manifest: docker/index.yaml
   helm-manifest-directory: manifests
-  target-chart-regex: cray-hms-.*
+  target-chart-regex: cray-hms-.*|cray-power-control
   sleep-duration-seconds: 5
   time-limit-minutes: 10
   webhook-sleep-seconds: 10

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -42,6 +42,7 @@ import requests
 import yaml
 import subprocess
 import urllib
+import git
 
 def GetDockerImageFromDiff(value, tag):
     # example: root['artifactory.algol60.net/csm-docker/stable']['images']['hms-trs-worker-http-v1'][0]
@@ -181,7 +182,11 @@ if __name__ == '__main__':
     for branch in config["configuration"]["targeted-csm-branches"]:
         logging.info("Checking out CSM branch {} for docker image extraction".format(branch))
 
-        csm_repo.git.checkout(branch)
+        try:
+            csm_repo.git.checkout(branch)
+        except git.exc.GitCommandError as e:
+            logging.error(f'Failed to checkout branch "{branch}", skipping')
+            continue
 
         # load the docker index file
         docker_index = os.path.join(csm_dir, config["configuration"]["docker-image-manifest"])
@@ -266,7 +271,11 @@ if __name__ == '__main__':
     all_charts = {}
     for branch in config["configuration"]["targeted-csm-branches"]:
         logging.info("Checking out CSM branch {} for helm chart image extraction".format(branch))
-        csm_repo.git.checkout(branch)
+        try:
+            csm_repo.git.checkout(branch)
+        except git.exc.GitCommandError as e:
+            logging.error(f'Failed to checkout branch "{branch}", skipping')
+            continue
         
         # its possible the same helm chart is referenced multiple times, so we should collapse the list
         # example download link: https://artifactory.algol60.net/artifactory/csm-helm-charts/stable/cray-hms-bss/cray-hms-bss-2.0.4.tgz

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -430,7 +430,13 @@ if __name__ == '__main__':
 
                     # Determine the names of the main application image, and the test image
                     images_repos_of_interest = []
-                    images_repos_of_interest.append(values["image"]["repository"])
+                    
+                    # The following is a WAR for the cray-power-control helm chart as it does things a little differently.
+                    if entry == "cray-power-control":
+                        images_repos_of_interest.append(values["cray-service"]["containers"]["cray-power-control"]["image"]["repository"])
+                    else:
+                        images_repos_of_interest.append(values["image"]["repository"])
+                    
                     if "testVersion" in values["global"]:
                         images_repos_of_interest.append(values["tests"]["image"]["repository"])
 


### PR DESCRIPTION
### Summary and Scope

Add release/1.4 branch, and speculative branches for future versions of CSM so they can be rebuilt automatically when they become available. If a branch doesn't exist in CSM, then continue on

Added PCS to the list of images to rebuild. The PCS chart is a little different, and required a chart specific WAR to identify the image repository for the chart.

In CSM 1.4 we added the full blown CAPMC to docker/index.yaml in the CSM repo to ensure we have a backup artifact if CAPMC Lite has issues. This image needs to be added so it can be automatically rebuilt

