### PR TITLE
Add rie to the list of images to get rebuilt automatically

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -1,4 +1,9 @@
 ---
+# Helm chart to artifactory folder mapping
+# Example:
+# Helm chart name: csm-redfish-interface-emulator
+# Download URL: https://artifactory.algol60.net/artifactory/csm-helm-charts/stable/csm-redfish-interface-emulator/csm-redfish-interface-emulator-0.1.0.tgz
+# Path: stable/csm-redfish-interface-emulator
 helm-repo-lookup:
   - chart: cray-hms-bss
     path: stable/cray-hms-bss
@@ -30,6 +35,8 @@ helm-repo-lookup:
     path: stable/hms-hmcollector
   - chart: cray-power-control
     path: stable/cray-hms-power-control
+  - chart: csm-redfish-interface-emulator
+    path: stable/csm-redfish-interface-emulator
 github-repo-image-lookup:
   - github-repo: hms-shcd-parser
     image: hms-shcd-parser
@@ -54,7 +61,7 @@ configuration:
     - stable/1.2
   docker-image-manifest: docker/index.yaml
   helm-manifest-directory: manifests
-  target-chart-regex: cray-hms-.*|cray-power-control
+  target-chart-regex: cray-hms-.*|cray-power-control|csm-redfish-interface-emulator
   sleep-duration-seconds: 5
   time-limit-minutes: 10
   webhook-sleep-seconds: 10


### PR DESCRIPTION
Add rie to the list of images to get rebuilt automatically. 

The workflow dispatcher with these changes was able to rebuild the RIE image: https://github.com/Cray-HPE/csm-redfish-interface-emulator/actions/runs/4926476551