### PR TITLE
Rebuild all hms-test images with version v3 and above.

### DIFF
--- a/configuration.yaml
+++ b/configuration.yaml
@@ -79,7 +79,7 @@ docker-image-compare:
         - find_me
 non-manifest-images:
 - github-repo: hms-test
-  tag-regex: v[3-4]\.[0-9]\.[0-9]
+  tag-regex: v[3-9]\.[0-9]+\.[0-9]+ # v1 and v2 images are not build in github, so ignore them.
   image_repo: artifactory.algol60.net/csm-docker/stable/hms-test
 - github-repo: hms-build-environment
   tag-regex: v1\.[0-9]\.[0-9]


### PR DESCRIPTION
 Rebuild all hms-test images with version v3 and above. v5 images were found to not be building. This will automatically pick any new versions of hms-test.

Test run: https://github.com/Cray-HPE/hms-build-workflow-dispatcher/actions/runs/5740077832

Successfully targeted the expected hms-test image versions: 
<img width="1242" alt="image" src="https://github.com/Cray-HPE/hms-build-workflow-dispatcher/assets/77114568/f52a21b1-5500-49a6-893b-569aca90970c">
