### PR TITLE
Casmhms 6042

### DIFF
--- a/.github/dispatch_workflows_summary_template.md.tpl
+++ b/.github/dispatch_workflows_summary_template.md.tpl
@@ -21,7 +21,7 @@
 			<td><a href="https://artifactory.algol60.net/ui/repos/tree/General/csm-docker%2Fstable%2F{{ $image.short_name }}%2F{{ $image.image_tag }}">{{$image.full_image}}</a></td>
 			<td>
                 <ul>
-                {{- range $branch := $image.csm_releases }}
+                {{- range $branch := $image.product_stream_releases }}
                     <li>{{$branch}}</li>
                 {{- end }}
                 </ul>

--- a/.github/workflows/dispatch_workflows.yaml
+++ b/.github/workflows/dispatch_workflows.yaml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         product-stream: ["csm", "spc"]
+      fail-fast: false
     name: Dispatch workflows
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/dispatch_workflows.yaml
+++ b/.github/workflows/dispatch_workflows.yaml
@@ -51,7 +51,7 @@ jobs:
           ARTIFACTORY_ALGOL60_READONLY_USERNAME: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
           ARTIFACTORY_ALGOL60_READONLY_TOKEN: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
           DISPATCHER_CONFIGURATION_FILE: configuration_${{ matrix.product-stream }}.yaml
-          DRYRUN: false
+          DRYRUN: true
         run: ./dispatcher.py
 
       - name: Render template

--- a/.github/workflows/dispatch_workflows.yaml
+++ b/.github/workflows/dispatch_workflows.yaml
@@ -51,7 +51,7 @@ jobs:
           ARTIFACTORY_ALGOL60_READONLY_USERNAME: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
           ARTIFACTORY_ALGOL60_READONLY_TOKEN: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
           DISPATCHER_CONFIGURATION_FILE: configuration_${{ matrix.product-stream }}.yaml
-          DRYRUN: true
+          DRYRUN: false
         run: ./dispatcher.py
 
       - name: Render template

--- a/.github/workflows/dispatch_workflows.yaml
+++ b/.github/workflows/dispatch_workflows.yaml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Render template
         id: template
-        uses: chuhlomin/render-template@v1.5
+        uses: chuhlomin/render-template@v1.7
         with:
           # It is expected the that the dispatch_workflows_summary_template.md.tpl is present in this repo.
           template: .github/dispatch_workflows_summary_template.md.tpl

--- a/.github/workflows/dispatch_workflows.yaml
+++ b/.github/workflows/dispatch_workflows.yaml
@@ -6,6 +6,9 @@ on:
     - cron: '0 7 * * *' #7am every day
 jobs:
   dispatch_workflows:
+    strategy:
+      matrix:
+        product-stream: ["csm", "spc"]
     name: Dispatch workflows
     runs-on: ubuntu-latest
     steps:
@@ -41,7 +44,8 @@ jobs:
           GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
           ARTIFACTORY_ALGOL60_READONLY_USERNAME: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_USERNAME }}
           ARTIFACTORY_ALGOL60_READONLY_TOKEN: ${{ secrets.ARTIFACTORY_ALGOL60_READONLY_TOKEN }}
-          DRYRUN: false
+          DISPATCHER_CONFIGURATION_FILE: configuration_${{ matrix.product-stream }}.yaml
+          DRYRUN: true
         run: ./dispatcher.py
 
       - name: Render template

--- a/.github/workflows/dispatch_workflows.yaml
+++ b/.github/workflows/dispatch_workflows.yaml
@@ -39,6 +39,11 @@ jobs:
           private-key: ${{ secrets.AUTOMATIC_WORKFLOW_DISPATCHER_APP_KEY }}
           app-id: ${{ secrets.AUTOMATIC_WORKFLOW_DISPATCHER_APP_ID }}
 
+      - name: Configure git for private repos
+        env:
+          GITHUB_TOKEN: ${{ steps.get-token.outputs.token }}
+        run: git config --global url."https://x:${GITHUB_TOKEN}@github.com".insteadOf "https://github.com"
+
       - name: Dispatch workflows
         shell: bash
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ helm_charts/
 *.tgz
 *.xlsx
 .idea/
+.env.sh
 
 # Prevent certificates from getting checked in
 *.ca

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 credentials.json
 csm/
+spc-product-stream/
+output/
 helm_charts/
 *tar.gz
 *.tgz
+*.xlsx
 .idea/
 
 # Prevent certificates from getting checked in

--- a/configuration_csm.yaml
+++ b/configuration_csm.yaml
@@ -48,7 +48,7 @@ github-repo-image-lookup:
     image: hardware-topology-assistant
 configuration:
   product-stream-repo: csm
-  targeted-csm-branches:
+  targeted-branches:
     - main
     - release/1.9
     - release/1.8

--- a/configuration_csm.yaml
+++ b/configuration_csm.yaml
@@ -47,7 +47,7 @@ github-repo-image-lookup:
   - github-repo: hardware-topology-assistant
     image: hardware-topology-assistant
 configuration:
-  manifest-repo: csm
+  product-stream-repo: csm
   targeted-csm-branches:
     - main
     - release/1.9

--- a/configuration_csm.yaml
+++ b/configuration_csm.yaml
@@ -60,6 +60,7 @@ configuration:
     - release/1.3
     - release/1.3.0
     - stable/1.2
+  targeted-branch-regexes: []
   docker-image-manifest: docker/index.yaml
   helm-manifest-directory: manifests
   target-chart-regex: cray-hms-.*|cray-power-control|csm-redfish-interface-emulator

--- a/configuration_csm.yaml
+++ b/configuration_csm.yaml
@@ -55,6 +55,7 @@ configuration:
     - release/1.7
     - release/1.6
     - release/1.5
+    - stable/1.5
     - release/1.4
     - release/1.3
     - release/1.3.0

--- a/configuration_spc.yaml
+++ b/configuration_spc.yaml
@@ -13,7 +13,7 @@ configuration:
   product-stream-repo: spc-product-stream
   targeted-branches: # Explicitly defined branches
     - main
-  targeted-branch-regexes:
+  targeted-branch-regexes: # Regexes to match 
     - release\/.+ # Match all release versions
   docker-image-manifest: docker/index.yaml
   helm-manifest-directory: manifests

--- a/configuration_spc.yaml
+++ b/configuration_spc.yaml
@@ -1,0 +1,24 @@
+---
+# Helm chart to artifactory folder mapping
+# Example:
+# Helm chart name: csm-redfish-interface-emulator
+# Download URL: https://artifactory.algol60.net/artifactory/csm-helm-charts/stable/csm-redfish-interface-emulator/csm-redfish-interface-emulator-0.1.0.tgz
+# Path: stable/csm-redfish-interface-emulator
+helm-repo-lookup:
+  - chart: spc
+    path: stable/spc
+github-repo-image-lookup: []
+configuration:
+  manifest-repo: spc-product-stream
+  targeted-csm-branches:
+    - main
+    - release\/.+ # Match all release versions
+  docker-image-manifest: docker/index.yaml
+  helm-manifest-directory: manifests
+  target-chart-regex: spc
+  sleep-duration-seconds: 5
+  time-limit-minutes: 10
+  webhook-sleep-seconds: 10
+  log-level: INFO
+docker-image-compare: {}
+non-manifest-images: []

--- a/configuration_spc.yaml
+++ b/configuration_spc.yaml
@@ -10,7 +10,7 @@ helm-repo-lookup:
     source_override: https://artifactory.algol60.net/artifactory/spc-helm-charts/
 github-repo-image-lookup: []
 configuration:
-  manifest-repo: spc-product-stream
+  product-stream-repo: spc-product-stream
   targeted-csm-branches:
     - main
     - release\/.+ # Match all release versions

--- a/configuration_spc.yaml
+++ b/configuration_spc.yaml
@@ -11,8 +11,9 @@ helm-repo-lookup:
 github-repo-image-lookup: []
 configuration:
   product-stream-repo: spc-product-stream
-  targeted-branches:
+  targeted-branches: # Explicitly defined branches
     - main
+  targeted-branch-regexes:
     - release\/.+ # Match all release versions
   docker-image-manifest: docker/index.yaml
   helm-manifest-directory: manifests

--- a/configuration_spc.yaml
+++ b/configuration_spc.yaml
@@ -7,6 +7,7 @@
 helm-repo-lookup:
   - chart: spc
     path: stable/spc
+    source_override: https://artifactory.algol60.net/artifactory/spc-helm-charts/
 github-repo-image-lookup: []
 configuration:
   manifest-repo: spc-product-stream

--- a/configuration_spc.yaml
+++ b/configuration_spc.yaml
@@ -11,7 +11,7 @@ helm-repo-lookup:
 github-repo-image-lookup: []
 configuration:
   product-stream-repo: spc-product-stream
-  targeted-csm-branches:
+  targeted-branches:
     - main
     - release\/.+ # Match all release versions
   docker-image-manifest: docker/index.yaml

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -44,6 +44,7 @@ import subprocess
 import urllib
 import git
 import pathlib
+import base64
 
 def GetDockerImageFromDiff(value, tag):
     # example: root['artifactory.algol60.net/csm-docker/stable']['images']['hms-trs-worker-http-v1'][0]
@@ -193,7 +194,13 @@ if __name__ == '__main__':
 
     os.mkdir(csm_dir)
     logging.info(f"Clone URL: {csm_repo_metadata.ssh_url}")
-    csm_repo = Repo.clone_from(csm_repo_metadata.ssh_url, csm_dir)
+    logging.info(f"Clone URL: {csm_repo_metadata.url}")
+    logging.info(f"Clone URL: {csm_repo_metadata.html_url}")
+    # csm_repo = Repo.clone_from(csm_repo_metadata.ssh_url, csm_dir, multi_options=[
+    #     f'--config http.https://github.com/.extraheader="AUTHORIZATION: basic {base64.b64encode(github_token.encode())}"'
+    # ])
+    clone_url = f'https://{github_token}@github.com/Cray-HPE/{csm}'
+    csm_repo = Repo.clone_from(clone_url, csm_dir)
     logging.info("retrieved manifest repo")
 
     ####################

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -192,8 +192,8 @@ if __name__ == '__main__':
         shutil.rmtree(csm_dir)
 
     os.mkdir(csm_dir)
-    clone_url = f'https://{github_token}@github.com/Cray-HPE/{csm}'
-    csm_repo = Repo.clone_from(clone_url, csm_dir)
+    logging.info(f"Clone URL: {csm_repo_metadata.ssh_url}")
+    csm_repo = Repo.clone_from(csm_repo_metadata.ssh_url, csm_dir)
     logging.info("retrieved manifest repo")
 
     ####################

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -44,7 +44,6 @@ import subprocess
 import urllib
 import git
 import pathlib
-import base64
 
 def GetDockerImageFromDiff(value, tag):
     # example: root['artifactory.algol60.net/csm-docker/stable']['images']['hms-trs-worker-http-v1'][0]
@@ -195,7 +194,7 @@ if __name__ == '__main__':
     os.mkdir(product_stream_repo_dir)
 
     clone_url = f'https://github.com/Cray-HPE/{product_stream_repo_name}'
-    logging.info(f"Product Stream Repo clone URL: {product_stream_repo_metadata.html_url}")
+    logging.info(f"Product stream repo clone URL: {clone_url}")
     product_stream_repo = Repo.clone_from(clone_url, product_stream_repo_dir)
     logging.info("retrieved manifest repo")
 

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -199,7 +199,7 @@ if __name__ == '__main__':
     # csm_repo = Repo.clone_from(csm_repo_metadata.ssh_url, csm_dir, multi_options=[
     #     f'--config http.https://github.com/.extraheader="AUTHORIZATION: basic {base64.b64encode(github_token.encode())}"'
     # ])
-    clone_url = f'https://{github_token}@github.com/Cray-HPE/{csm}'
+    clone_url = f'https://github.com/Cray-HPE/{csm}'
     csm_repo = Repo.clone_from(clone_url, csm_dir)
     logging.info("retrieved manifest repo")
 

--- a/dispatcher.py
+++ b/dispatcher.py
@@ -192,8 +192,8 @@ if __name__ == '__main__':
         shutil.rmtree(csm_dir)
 
     os.mkdir(csm_dir)
-    logging.info(f"Clone URL: {csm_repo_metadata.ssh_url}")
-    csm_repo = Repo.clone_from(csm_repo_metadata.ssh_url, csm_dir)
+    clone_url = f'https://{github_token}@github.com/Cray-HPE/{csm}'
+    csm_repo = Repo.clone_from(clone_url, csm_dir)
     logging.info("retrieved manifest repo")
 
     ####################


### PR DESCRIPTION
### Summary and Scope

Add support for rebuilding the SPC product stream.

* Renamed CSM references in `dispatcher.py` to "product stream"
* Allow for a configurable configuration file to be specified via `DISPATCHER_CONFIGURATION_FILE`
* Added an config file option to specify a regex for targeted branches
* Added `source_override` for helm charts specified in `the helm-repo-lookup` to specify where in artifactory to download the helm chart. This is needed for loftsman manifests that lack information in `.spec.sources.charts`.  

### Issues and Related PRs

LIST AND CHARACTERIZE RELATIONSHIP TO JIRA ISSUES AND OTHER PULL REQUESTS. BE SURE LIST DEPENDENCIES.

* Resolves CASMHMS-6042

### Testing

LIST THE ENVIRONMENTS IN WHICH THESE CHANGES WERE TESTED.

Tested on:
* Github actions

See https://github.com/Cray-HPE/hms-build-workflow-dispatcher/actions/runs/5931339848?pr=14

### Risks and Mitigations

Low risk
